### PR TITLE
Update cordova install/update script, missing motion plugin

### DIFF
--- a/scripts/update_cordova.sh
+++ b/scripts/update_cordova.sh
@@ -6,7 +6,7 @@ cordova platform update android
 echo "Current plugin versions"
 cordova plugin
 cordova plugin remove org.apache.cordova.device-motion
-cordova plugin org.apache.cordova.device-motion
+cordova plugin add org.apache.cordova.device-motion
 cordova plugin remove com.randdusing.bluetoothle
 cordova plugin add com.randdusing.bluetoothle
 cordova plugin remove org.apache.cordova.device

--- a/scripts/update_cordova.sh
+++ b/scripts/update_cordova.sh
@@ -5,6 +5,8 @@ cordova platform update android
 
 echo "Current plugin versions"
 cordova plugin
+cordova plugin remove org.apache.cordova.device-motion
+cordova plugin org.apache.cordova.device-motion
 cordova plugin remove com.randdusing.bluetoothle
 cordova plugin add com.randdusing.bluetoothle
 cordova plugin remove org.apache.cordova.device


### PR DESCRIPTION
The cordova motion plugin `org.apache.cordova.device-motion` is missing from the update_cordova script but is used in the app (building fails without it).

